### PR TITLE
Add Telegram feedback

### DIFF
--- a/src/components/elements/modal/modalContactUs.jsx
+++ b/src/components/elements/modal/modalContactUs.jsx
@@ -31,18 +31,27 @@ export function ModalContact() {
     }, [requestCall])
     const { register, formState: { errors }, handleSubmit } = useForm();
 
-    function onSubmit(data) {
-        window.Email.send({
-            Host: "smtp.elasticemail.com",
-            Username: "elenergo34@gmail.com",
-            Password: "3E5AC02565E51C89D2B8DB44B11779986186",
-            To: "elenergo34@yandex.ru",
-            From: "elenergo34@gmail.com",
-            Subject: "Новый клиент",
-            Body: `Имя: ${data.name}, Номер телефона: ${data.phone}, Электронная почта ${data.mail} `
-        }).then(
-            message => alert(message)
-        );
+    async function onSubmit(data) {
+        try {
+            const response = await fetch('/api/send-telegram', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    name: data.name,
+                    phone: data.phone,
+                    email: data.mail
+                })
+            });
+            if (response.ok) {
+                alert('Заявка отправлена');
+            } else {
+                alert('Ошибка отправки');
+            }
+        } catch (e) {
+            alert('Ошибка отправки');
+        }
     }
 
     return (

--- a/src/components/footer/contactUs.jsx
+++ b/src/components/footer/contactUs.jsx
@@ -13,18 +13,27 @@ function ContactUs() {
 
     const { register, formState: { errors }, handleSubmit } = useForm();
 
-    function onSubmit(data) {
-        window.Email.send({
-            Host: "smtp.elasticemail.com",
-            Username: "elenergo34@gmail.com",
-            Password: "3E5AC02565E51C89D2B8DB44B11779986186",
-            To: "elenergo34@yandex.ru",
-            From: "elenergo34@gmail.com",
-            Subject: "Новый клиент",
-            Body: `Имя: ${data.name}, Номер телефона: ${data.phone}, Электронная почта ${data.email} `
-        }).then(
-            message => alert(message)
-        );
+    async function onSubmit(data) {
+        try {
+            const response = await fetch('/api/send-telegram', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    name: data.name,
+                    phone: data.phone,
+                    email: data.mail
+                })
+            });
+            if (response.ok) {
+                alert('Заявка отправлена');
+            } else {
+                alert('Ошибка отправки');
+            }
+        } catch (e) {
+            alert('Ошибка отправки');
+        }
     }
 
 


### PR DESCRIPTION
## Summary
- send feedback via Telegram on the backend
- use new endpoint in footer and modal forms

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866503bcf4083248476ba794deabd0a