### PR TITLE
Fix pg import with ES modules

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -1,5 +1,6 @@
 // db.js
-import { Pool } from 'pg';
+import pkg from 'pg';
+const { Pool } = pkg;
 import path from 'path';
 import dotenv from 'dotenv';
 


### PR DESCRIPTION
## Summary
- adjust `pg` import in server/db.js for compatibility with Node ES modules

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68695d6ea39c8324b9d5439145c42158