### PR TITLE
Integrate backend with database and frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "server": "node server/index.js",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
@@ -71,5 +72,6 @@
   },
   "devDependencies": {
     "typescript": "^4.9.5"
-  }
+  },
+  "proxy": "http://localhost:4000"
 }

--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+node "$(dirname "$0")/../server/index.js"

--- a/server/db.js
+++ b/server/db.js
@@ -2,6 +2,7 @@
 import pkg from 'pg';
 const { Pool } = pkg;
 import path from 'path';
+import fs from 'fs';
 import dotenv from 'dotenv';
 
 dotenv.config({ path: path.resolve('../.env') });
@@ -15,17 +16,8 @@ const pool = new Pool({
 });
 
 export async function initDB() {
-  await pool.query(`
-    CREATE TABLE IF NOT EXISTS posts (
-      id SERIAL PRIMARY KEY,
-      category VARCHAR(50) NOT NULL,
-      title TEXT NOT NULL,
-      description TEXT,
-      image TEXT,
-      url TEXT,
-      details JSONB
-    );
-  `);
+  const schema = fs.readFileSync(new URL('./schema.sql', import.meta.url), 'utf-8');
+  await pool.query(schema);
 }
 
 export default pool;

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS posts (
+  id SERIAL PRIMARY KEY,
+  category VARCHAR(50) NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT,
+  image TEXT,
+  url TEXT,
+  details JSONB
+);
+

--- a/src/axios/axios.js
+++ b/src/axios/axios.js
@@ -1,13 +1,16 @@
-import axios from "axios"
+import axios from "axios";
+
+const baseURL = process.env.REACT_APP_API_BASE
+  ? `${process.env.REACT_APP_API_BASE}/api`
+  : '/api';
 
 const instance = axios.create({
-    baseURL: "https://el-energo.ru/api/"
-
-})
+  baseURL,
+});
 
 instance.interceptors.request.use((config) => {
-    config.headers.Authorization = window.localStorage.getItem('token') // Если любой запрос происходит проверяем авторизацию
-return config
-})
+  config.headers.Authorization = window.localStorage.getItem('token');
+  return config;
+});
 
 export default instance;

--- a/src/components/adminPannel/post/edit.jsx
+++ b/src/components/adminPannel/post/edit.jsx
@@ -12,6 +12,8 @@ import SimpleMDE from 'react-simplemde-editor';
 import { useNavigate, useParams, useLocation } from "react-router-dom"
 import { create } from "@mui/material/styles/createTransitions"
 
+const API_BASE = process.env.REACT_APP_API_BASE || '';
+
 const styleTitle = {
   fontFamily: "SourceCodePro-SemiBold",
   fontSize: "24px",
@@ -90,7 +92,7 @@ function EditPost() {
       formData.append('image', file)
       const { data } = await axios.post('/uploads', formData)
       console.log(data)
-      setImageUrl(`http://localhost:4000${data.url}`)
+      setImageUrl(`${API_BASE}${data.url}`)
     } catch (err) {
       console.warn(err)
       alert('Ошибка загрузки фото')
@@ -104,7 +106,7 @@ function EditPost() {
       formData.append('image', file)
       const { data } = await axios.post('/uploads', formData)
       console.log(data)
-      arrayTimes.push(`http://localhost:4000${data.url}`)
+      arrayTimes.push(`${API_BASE}${data.url}`)
       console.log(arrayTimes);
       setUpdate(true)
     } catch (err) {


### PR DESCRIPTION
## Summary
- load DB schema from `server/schema.sql`
- use new schema file to init database
- make axios base URL configurable via environment variable
- use API base URL when uploading images in admin panel
- add server start helper script and npm script
- configure React proxy for dev environment

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68696c94225c8324b5a247a2589759c0