### PR TITLE
Fix .env path loading in server

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -4,8 +4,12 @@ const { Pool } = pkg;
 import path from 'path';
 import fs from 'fs';
 import dotenv from 'dotenv';
+import { fileURLToPath } from 'url';
 
-dotenv.config({ path: path.resolve('../.env') });
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.resolve(__dirname, '../.env') });
 
 const pool = new Pool({
   user: process.env.DB_USER,

--- a/server/index.js
+++ b/server/index.js
@@ -5,8 +5,12 @@ import https from 'https'
 import path from 'path'
 import dotenv from 'dotenv'
 import pool, { initDB } from './db.js'
+import { fileURLToPath } from 'url'
 
-dotenv.config({ path: path.resolve('../.env') })
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+dotenv.config({ path: path.resolve(__dirname, '../.env') })
 
 const app = express();
 


### PR DESCRIPTION
## Summary
- resolve environment path relative to server files

## Testing
- `npm run server` *(fails: Cannot find package 'express' because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686fa6b00f4083248f8a2fd89d772dc6