### PR TITLE
Add fallback contact stubs for header contact buttons

### DIFF
--- a/src/components/header/contactButtons/contactBtn.jsx
+++ b/src/components/header/contactButtons/contactBtn.jsx
@@ -3,37 +3,54 @@ import WhatsAppIco from './icon/Vector.png'
 import Typography from '@mui/material/Typography'
 import MailIco from './icon/gmail 1.png'
 import CallIco from './icon/call.png'
-import { Link, NavLink, useNavigate } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { useSelector } from 'react-redux'
 
 
 
 
 function ButtonsBox() {
-    const navigate = useNavigate();
-    const {contact} = useSelector((state) => state.contact)
-    
+    const { contact } = useSelector((state) => state.contact)
+
+    const normalizeContact = (value = '') => value.replace(/\s+/g, '').replace(/[^+\d]/g, '')
+
+    const fallbackContact = {
+        phone: '+7 (999) 000-00-00',
+        whatsapp: '+7 (999) 000-00-00',
+        email: 'info@elenergo.ru',
+    }
+
+    const contactItem = contact?.items?.[0] || {}
+    const mergedContact = {
+        phone: contactItem.phone || fallbackContact.phone,
+        whatsapp: contactItem.whatsapp || fallbackContact.whatsapp,
+        email: contactItem.email || fallbackContact.email,
+    }
+
+    const normalizedPhone = normalizeContact(contactItem.phone) || normalizeContact(fallbackContact.phone)
+    const normalizedWhatsApp = normalizeContact(contactItem.whatsapp) || normalizeContact(fallbackContact.whatsapp)
+
     const IconItems = [
         {
             src: CallIco,
             name: "Звонок",
-            url: `tel:${contact.items[0].phone}`
+            url: normalizedPhone ? `tel:${normalizedPhone.startsWith('+') ? normalizedPhone : `+${normalizedPhone}`}` : 'tel:+79990000000'
         },
         {
             src: WhatsAppIco,
             name: "Whats App",
-            url: 'https://wa.me/79275040200'
+            url: normalizedWhatsApp ? `https://wa.me/${normalizedWhatsApp.replace('+', '')}` : 'https://wa.me/79990000000'
         },
         {
             src: MailIco,
             name: "E-mail",
-            url: 'mailto:elenergo34@gmail.com'
+            url: `mailto:${mergedContact.email}`
         }
     ]
 
     const allBtnContacts = IconItems.map((item) => {
         return (
-            <Link to={item.url}>
+            <Link key={item.name} to={item.url}>
             <div onClick={() => {
             }} className={s.iconContentAlign}>
                 <div className={s.btnBox}>


### PR DESCRIPTION
## Summary
- add fallbacks to the header contact buttons so they no longer crash when the contact store is empty
- sanitize phone, WhatsApp, and email links while preferring live data when it is available
- remove unused router utilities and add stable keys for the rendered buttons

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f0cf1fac0c832a89ab2cb554cd606e